### PR TITLE
add `radar` and `wait` functions

### DIFF
--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/DeadCodeEliminator.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/DeadCodeEliminator.java
@@ -84,9 +84,16 @@ class DeadCodeEliminator implements LogicInstructionPipeline {
                 visitUcontrol(instruction);
                 break;
 
+            case "wait":
+                visitWait(instruction);
+                break;
+
             case "sensor":
                 visitSensor(instruction);
                 break;
+
+            case "radar":
+                visitRadar(instruction);
 
             case "ubind":
                 visitUbind(instruction);
@@ -272,6 +279,17 @@ class DeadCodeEliminator implements LogicInstructionPipeline {
         reads.add(instruction.getArgs().get(2));
     }
 
+    private void visitRadar(LogicInstruction instruction) {
+        // radar prop1 prop2 prop3 sortby target order out
+        reads.add(instruction.getArgs().get(0));
+        reads.add(instruction.getArgs().get(1));
+        reads.add(instruction.getArgs().get(2));
+        reads.add(instruction.getArgs().get(3));
+        reads.add(instruction.getArgs().get(4));
+        reads.add(instruction.getArgs().get(5));
+        addWrite(instruction, 6);
+    }
+
     private void visitSet(LogicInstruction instruction) {
         addWrite(instruction, 0);
         reads.add(instruction.getArgs().get(1));
@@ -298,6 +316,10 @@ class DeadCodeEliminator implements LogicInstructionPipeline {
         addWrite(instruction, 1);
         if (instruction.getArgs().size() > 2) reads.add(instruction.getArgs().get(2));
         if (instruction.getArgs().size() > 3) reads.add(instruction.getArgs().get(3));
+    }
+
+    private void visitWait(LogicInstruction instruction) {
+        reads.add(instruction.getArgs().get(0));
     }
 
     private void visitUcontrol(LogicInstruction instruction) {

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/LogicInstructionGenerator.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/LogicInstructionGenerator.java
@@ -209,6 +209,9 @@ public class LogicInstructionGenerator extends BaseAstVisitor<String> {
             case "printflush":
                 return handlePrintflush(params);
 
+            case "wait":
+                return handleWait(params);
+
             case "ubind":
                 return handleUbind(params);
 
@@ -220,6 +223,9 @@ public class LogicInstructionGenerator extends BaseAstVisitor<String> {
 
             case "getlink":
                 return handleGetlink(params);
+
+            case "radar":
+                return handleRadar(params);
 
             case "mine":
                 return handleMine(params);
@@ -681,6 +687,37 @@ public class LogicInstructionGenerator extends BaseAstVisitor<String> {
         return tmp;
     }
 
+    private boolean isRadarSearchProperty(String prop) {
+        return List.of("attacker", "enemy", "ally", "player", "flying", "ground", "boss", "any").contains(prop);
+    }
+    private boolean isRadarSortbyOption(String sortby) {
+        return List.of("distance", "health", "shield", "armor", "maxHealth").contains(sortby);
+    }
+
+    private String handleRadar(List<String> params) {
+        // radar prop1 prop2 prop3 sortby target order out
+        final String tmp = nextTemp();
+        final String prop1 = params.get(0);
+        final String prop2 = params.get(1);
+        final String prop3 = params.get(2);
+        final String sortby = params.get(3);
+        // Radar search properties should be hardcoded and can't be indirectly referenced. (Last test: v7.0.1.)
+        if (!isRadarSearchProperty(prop1)) {
+            throw new GenerationException("Invalid radar search property [" + prop1 + "]");
+        }
+        if (!isRadarSearchProperty(prop2)) {
+            throw new GenerationException("Invalid radar search property [" + prop2 + "]");
+        }
+        if (!isRadarSearchProperty(prop3)) {
+            throw new GenerationException("Invalid radar search property [" + prop3 + "]");
+        }
+        if (!isRadarSortbyOption(sortby)) {
+            throw new GenerationException("Invalid radar sort option [" + sortby + "]");
+        }
+        pipeline.emit(new LogicInstruction("radar", params.get(0), params.get(1), params.get(2), params.get(3), params.get(4), params.get(5), tmp));
+        return tmp;
+    }
+
     private String handleRand(List<String> params) {
         // op rand result 200 0
         final String tmp = nextTemp();
@@ -708,6 +745,11 @@ public class LogicInstructionGenerator extends BaseAstVisitor<String> {
     private String handlePrint(List<String> params) {
         params.forEach((param) -> pipeline.emit(new LogicInstruction("print", List.of(param))));
         return params.get(params.size() - 1);
+    }
+
+    private String handleWait(List<String> params) {
+        pipeline.emit(new LogicInstruction("wait", params.get(0)));
+        return "null";
     }
 
     @Override

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/LogicInstructionPrinter.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/LogicInstructionPrinter.java
@@ -17,10 +17,12 @@ public class LogicInstructionPrinter {
         args.put("print", 1);
         args.put("end", 0);
         args.put("sensor", 3);
+        args.put("radar", 7);
         args.put("control", 6);
         args.put("draw", 7);
         args.put("write", 3);
         args.put("read", 3);
+        args.put("wait", 1);
         args.put("drawflush", 1);
         args.put("ubind", 1);
         args.put("ucontrol", 6);

--- a/compiler/src/test/java/info/teksol/mindcode/mindustry/LogicInstructionGeneratorTest.java
+++ b/compiler/src/test/java/info/teksol/mindcode/mindustry/LogicInstructionGeneratorTest.java
@@ -592,6 +592,51 @@ class LogicInstructionGeneratorTest extends AbstractGeneratorTest {
     }
 
     @Test
+    void generatesRadar() {
+        assertLogicInstructionsMatch(
+                List.of(
+                        new LogicInstruction("set", var(0), "1"),
+                        new LogicInstruction("radar", "enemy", "any", "any", "distance", "salvo1", var(0), var(1)),
+                        new LogicInstruction("set", "out", var(1)),
+                        new LogicInstruction("set", var(2), "1"),
+                        new LogicInstruction("radar", "ally", "flying", "any", "health", "lancer1", var(2), var(3)),
+                        new LogicInstruction("set", "out", var(3)),
+                        new LogicInstruction("set", "src", "salvo1"),
+                        new LogicInstruction("set", var(4), "1"),
+                        new LogicInstruction("radar", "enemy", "any", "any", "distance", "src", var(4), var(5)),
+                        new LogicInstruction("set", "out", var(5)),
+                        new LogicInstruction("end")
+                ),
+                LogicInstructionGenerator.generateUnoptimized(
+                        (Seq) translateToAst("" +
+                                "out = radar(enemy, any, any, distance, salvo1, 1)\n" +
+                                "out = radar(ally, flying, any, health, lancer1, 1)\n" +
+                                "src = salvo1\n" +
+                                "out = radar(enemy, any, any, distance, src, 1, out)\n"
+                        )
+                )
+        );  
+    }
+
+    @Test
+    void generatesWait() {
+        assertLogicInstructionsMatch(
+                List.of(
+                        new LogicInstruction("set", var(0), "1"),
+                        new LogicInstruction("wait", var(0)),
+                        new LogicInstruction("set", var(1), "0.001"),
+                        new LogicInstruction("wait", var(1)),
+                        new LogicInstruction("set", var(2), "1000"),
+                        new LogicInstruction("wait", var(2)),
+                        new LogicInstruction("end")
+                ),
+                LogicInstructionGenerator.generateUnoptimized(
+                        (Seq) translateToAst("wait(1)\nwait(0.001)\nwait(1000)")
+                )
+        );  
+    }
+
+    @Test
     void generatesEndFromFunctionCall() {
         assertLogicInstructionsMatch(
                 List.of(


### PR DESCRIPTION
This PR adds two functions from Mindustry Logic missing in Mindcode's built-in functions:

- `radar`. Locate units from a building.
  - `building = radar(prop1, prop2, prop3, sortby, sort)` ⇔ `radar prop1 prop2 prop3 sortby building sort`
  - `propX` must be one of any, enemy, attacker, ally, player, ground, flying, or boss. These must be hardcoded and can't be substituted with an indirect reference (seems like an issues with Mindustry).
  - `sortby` must be one of distance, health, shield, armor, or maxHealth.
- `wait`. Delays for `delay` seconds. Can be a decimal number.
  - `wait(delay)` ⇔ `wait delay`

Test cases have been added LogicInstructionGeneratorTest.java.