### PR TITLE
allow mindcode to be used through the terminal

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+$MINDCODE_PATH/mvnw install

--- a/bin/mindcode
+++ b/bin/mindcode
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+jar=$( find "$MINDCODE_PATH/webapp" -type f -name '*.jar' | tr '\n' ':' )
+exec java -classpath $jar info.teksol.mindcode.webapp.CompileMain $@

--- a/webapp/src/main/java/info/teksol/mindcode/webapp/CompileMain.java
+++ b/webapp/src/main/java/info/teksol/mindcode/webapp/CompileMain.java
@@ -1,0 +1,73 @@
+package info.teksol.mindcode.webapp;
+
+import info.teksol.mindcode.Tuple2;
+import java.nio.file.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import static info.teksol.mindcode.webapp.CompilerFacade.compile;
+
+public class CompileMain {
+    static private String readFile(String filename) throws IOException {
+        try (final BufferedReader reader = new BufferedReader(new FileReader(filename))) {
+            final StringWriter out = new StringWriter();
+            reader.transferTo(out);
+            return out.toString();
+        }
+    }
+
+    static private boolean compileMindcode(String contents, boolean optimise) {
+        final Tuple2<String, List<String>> result = compile(contents, optimise);
+
+        final String compiledCode = result._1;
+        final List<String> syntaxErrors = result._2;
+
+        if (!syntaxErrors.isEmpty()) {
+            // Print errors to stderr.
+            for (int i = 0; i < syntaxErrors.size(); i++) {
+                System.err.println(syntaxErrors.get(i));
+            }
+            return false;
+        } else {
+            // No errors? Print the compiled code.
+            System.out.println(compiledCode);
+            return true;
+        }
+    }
+
+    static public void main(String[] args) throws IOException {
+        boolean optimise = false;
+        String filename = null;
+        for (int i = 0; i < args.length; i++) {
+            if (args[i].equals("-o")) {
+                optimise = true;
+            } else if (filename == null) {
+                // Store the first non-option string found.
+                filename = args[i];
+            }
+        }
+
+        if (filename == null) {
+            // No filenames? Read directly from stdin.
+            BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+            String contents = "";
+            String line = null;
+            while ((line = br.readLine()) != null) {
+                contents += line + "\n";
+            }
+            compileMindcode(contents, optimise);
+
+        } else {
+            String contents = readFile(filename);
+            if (!compileMindcode(contents, optimise)) {
+                System.exit(1);
+            }
+        }
+    }
+}

--- a/webapp/src/main/java/info/teksol/mindcode/webapp/CompileMain.java
+++ b/webapp/src/main/java/info/teksol/mindcode/webapp/CompileMain.java
@@ -1,14 +1,11 @@
 package info.teksol.mindcode.webapp;
 
 import info.teksol.mindcode.Tuple2;
-import java.nio.file.*;
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
-import java.util.ArrayList;
 import java.util.List;
 
 import static info.teksol.mindcode.webapp.CompilerFacade.compile;

--- a/webapp/src/main/java/info/teksol/mindcode/webapp/CompileMain.java
+++ b/webapp/src/main/java/info/teksol/mindcode/webapp/CompileMain.java
@@ -25,16 +25,16 @@ public class CompileMain {
         final String compiledCode = result._1;
         final List<String> syntaxErrors = result._2;
 
-        if (!syntaxErrors.isEmpty()) {
+        if (syntaxErrors.isEmpty()) {
+            // No errors? Print the compiled code.
+            System.out.println(compiledCode);
+            return true;
+        } else {
             // Print errors to stderr.
             for (int i = 0; i < syntaxErrors.size(); i++) {
                 System.err.println(syntaxErrors.get(i));
             }
             return false;
-        } else {
-            // No errors? Print the compiled code.
-            System.out.println(compiledCode);
-            return true;
         }
     }
 

--- a/webapp/src/main/java/info/teksol/mindcode/webapp/CompileMain.java
+++ b/webapp/src/main/java/info/teksol/mindcode/webapp/CompileMain.java
@@ -31,8 +31,8 @@ public class CompileMain {
             return true;
         } else {
             // Print errors to stderr.
-            for (int i = 0; i < syntaxErrors.size(); i++) {
-                System.err.println(syntaxErrors.get(i));
+            for (String err : syntaxErrors) {
+                System.err.println(err);
             }
             return false;
         }
@@ -50,21 +50,21 @@ public class CompileMain {
             }
         }
 
+        String contents = "";
+
         if (filename == null) {
             // No filenames? Read directly from stdin.
             BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-            String contents = "";
             String line = null;
             while ((line = br.readLine()) != null) {
                 contents += line + "\n";
             }
-            compileMindcode(contents, optimise);
-
         } else {
-            String contents = readFile(filename);
-            if (!compileMindcode(contents, optimise)) {
-                System.exit(1);
-            }
+            contents = readFile(filename);
+        }
+
+        if (!compileMindcode(contents, optimise)) {
+            System.exit(1);
         }
     }
 }


### PR DESCRIPTION
Now we can use VSCode's CodeRunner or a simple shell script to one-button-compile mindcode to mlog. ;)

This PR aims for MindCode to be a command-line program, to easily integrate with other functions. The result, as you can see below, is a somewhat hacky pile of Java borrowing mostly from the webapp's `CompilerFacade.compile` and copypasta from numerous stack overflow posts. 

Currently, the program is able to accept input:

1. from a file (e.g. `mindcode filename.mindcode`) or 
2. from standard input, if no file is provided (e.g. `mindcode <filename.mindcode`).

Mlog codegen is printed to stdout. Syntax errors are printed to stderr.

Moreover, we can specify optimisations using a `-o` flag (e.g. `mindcode -o filename.mindcode`).

---

For `bin/build` and `bin/compile`, we need to first define a `$MINDCODE_PATH` var pointing to the mindcode repository. (This could be defined in, say, the .bashrc/.zshrc startup file.)

With VSCode's coderunner, we can then do
```js
"code-runner.executorMap": {
    "mindcode": "$MINDCODE_PATH/bin/mindcode -o $dir/$fileName >$workspaceRoot/build/$fileNameWithoutExt.mlog",
}
```