### PR TITLE
OptimizeOpThenSet fix

### DIFF
--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/DeadCodeEliminator.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/DeadCodeEliminator.java
@@ -260,7 +260,8 @@ class DeadCodeEliminator implements LogicInstructionPipeline {
     }
 
     private void visitGetlink(LogicInstruction instruction) {
-        reads.add(instruction.getArgs().get(0));
+        addWrite(instruction, 0);
+        reads.add(instruction.getArgs().get(1));
     }
 
     private void visitControl(LogicInstruction instruction) {

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/OptimizeOpThenSet.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/OptimizeOpThenSet.java
@@ -57,8 +57,12 @@ class OptimizeOpThenSet implements LogicInstructionPipeline {
         public State emit(LogicInstruction instruction) {
             if (!instruction.isSet()) {
                 next.emit(op);
-                next.emit(instruction);
-                return new EmptyState();
+                if (instruction.isOp()) {
+                    return new ExpectSet(instruction);
+                } else {
+                    next.emit(instruction);
+                    return new EmptyState();
+                }
             }
 
             if (!instruction.getArgs().get(1).equals(op.getArgs().get(1))) {

--- a/compiler/src/test/java/info/teksol/mindcode/mindustry/OptimizeOpThenSetTest.java
+++ b/compiler/src/test/java/info/teksol/mindcode/mindustry/OptimizeOpThenSetTest.java
@@ -26,6 +26,25 @@ class OptimizeOpThenSetTest extends AbstractGeneratorTest {
                 terminus.getResult()
         );
     }
+    
+    @Test
+    void optimizesOpOpThenSet() {
+        LogicInstructionGenerator.generateInto(
+                sut,
+                (Seq) translateToAst(
+                        "state = min(max(state, MIN), MAX)"
+                )
+        );
+
+        assertLogicInstructionsMatch(
+                List.of(
+                        new LogicInstruction("op", "max", var(0), "state", "MIN"),
+                        new LogicInstruction("op", "min", "state", var(0), "MAX"),
+                        new LogicInstruction("end")
+                ),
+                terminus.getResult()
+        );
+    }
 
     @Test
     void optimizesOpThenSetFromBinaryOp() {


### PR DESCRIPTION
This PR fixes a small bug in the OptimizeOpThenSet, which causes it to miss some cases that should be handled.

Details of the issue: the ExpectSet state is entered upon encountering an `op` instruction, and exited when encountered anything other than `set` instruction. When sequence of instructions is [`op`, `op`, `set`], the optimizer misses the second one - it leaves the ExpectedSet state instead of advancing just one instruction while remaining in the ExpectedSet state.

The issue manifests itself on `state = min(max(state, MIN), MAX)`, producing
```
op max __tmp0 state MIN
op min __tmp1 __tmp0 MAX
set state __tmp1
```
instead of
```
op max __tmp0 state MIN
op min state __tmp0 MAX
```
I've updated the unit tests to catch this case and fixed the issue in the OptimizeOpThenSet class.
