### PR TITLE
fixes #62

### DIFF
--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/ImproveConditionalJumps.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/ImproveConditionalJumps.java
@@ -61,6 +61,12 @@ public class ImproveConditionalJumps implements LogicInstructionPipeline {
             return;
         }
 
+        // Do not remove previous instruction if it sets user defined variable
+        if (!previous.getArgs().get(1).startsWith(LogicInstructionGenerator.TMP_PREFIX)) {
+            flushNext(instruction);
+            return;
+        }
+
         if (!inverses.containsKey(previous.getArgs().get(0))) {
             throw new IllegalArgumentException("Unknown operation passed-in; can't find the inverse of [" + previous.getArgs().get(0) + "]");
         }

--- a/compiler/src/test/java/info/teksol/mindcode/mindustry/ImproveConditionalJumpsTest.java
+++ b/compiler/src/test/java/info/teksol/mindcode/mindustry/ImproveConditionalJumpsTest.java
@@ -87,4 +87,40 @@ class ImproveConditionalJumpsTest extends AbstractGeneratorTest {
         );
     }
 
+    @Test
+    void preservesUserVariables() {
+        // We need our own pipeline for this test
+        final LogicInstructionPipeline customPipeline = 
+                new DeadCodeEliminator(
+                        new OptimizeOpThenSet(
+                                new ImproveConditionalJumps(terminus)
+                        )
+                );
+
+    
+        LogicInstructionGenerator.generateInto(
+                customPipeline,
+                (Seq) translateToAst(
+                        "alive = @unit.dead === 0\n" +
+                                "if alive\n" +
+                                "  print(alive)\n" +
+                                "end"
+                )
+        );
+
+        assertLogicInstructionsMatch(
+                List.of(
+                        new LogicInstruction("sensor", var(0), "@unit", "@dead"),
+                        new LogicInstruction("set", var(1), "0"),
+                        new LogicInstruction("op", "strictEqual", "alive", var(0), var(1)),
+                        new LogicInstruction("jump", var(1000), "notEqual", "alive", "true"),
+                        new LogicInstruction("print", "alive"),
+                        new LogicInstruction("jump", var(1001), "always"),
+                        new LogicInstruction("label", var(1000)),
+                        new LogicInstruction("label", var(1001)),
+                        new LogicInstruction("end")
+                ),
+                terminus.getResult()
+        );
+    }
 }


### PR DESCRIPTION
This PR prevents ImproveConditionalJumps from removing op instructions that set a user defined variable (issue #62). Contains unit test to catch the issue and a fix.

The issue only manifests itself on partially optimized code. I've created a custom instruction pipeline for the new unit test - would that be okay?