### PR TITLE
Issue #64 fix

### DIFF
--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/ImproveConditionalJumps.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/ImproveConditionalJumps.java
@@ -17,8 +17,7 @@ public class ImproveConditionalJumps implements LogicInstructionPipeline {
             "lessThan", "greaterThanEq",
             "lessThanEq", "greaterThan",
             "greaterThan", "lessThanEq",
-            "greaterThanEq", "lessThan",
-            "strictEqual", "notEqual"
+            "greaterThanEq", "lessThan"
     );
     private static final Set<String> COMPARISON_OPERATORS = inverses.keySet();
     private final LogicInstructionPipeline next;

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/OptimizeGetlinkThenSet.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/OptimizeGetlinkThenSet.java
@@ -16,6 +16,7 @@ class OptimizeGetlinkThenSet implements LogicInstructionPipeline {
     @Override
     public void flush() {
         state = state.flush();
+        next.flush();
     }
 
     private interface State {

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/OptimizeOpThenSet.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/OptimizeOpThenSet.java
@@ -20,6 +20,7 @@ class OptimizeOpThenSet implements LogicInstructionPipeline {
     @Override
     public void flush() {
         state = state.flush();
+        next.flush();
     }
 
     private interface State {
@@ -41,7 +42,6 @@ class OptimizeOpThenSet implements LogicInstructionPipeline {
 
         @Override
         public State flush() {
-            next.flush();
             return this;
         }
     }

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/OptimizeReadThenSet.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/OptimizeReadThenSet.java
@@ -17,6 +17,7 @@ class OptimizeReadThenSet implements LogicInstructionPipeline {
     @Override
     public void flush() {
         state = state.flush();
+        next.flush();
     }
 
     private interface State {
@@ -38,7 +39,6 @@ class OptimizeReadThenSet implements LogicInstructionPipeline {
 
         @Override
         public State flush() {
-            next.flush();
             return this;
         }
     }

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/OptimizeSensorThenSet.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/OptimizeSensorThenSet.java
@@ -16,6 +16,7 @@ class OptimizeSensorThenSet implements LogicInstructionPipeline {
     @Override
     public void flush() {
         state = state.flush();
+        next.flush();
     }
 
     private interface State {

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/OptimizeSetThenOp.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/OptimizeSetThenOp.java
@@ -17,6 +17,7 @@ class OptimizeSetThenOp implements LogicInstructionPipeline {
     @Override
     public void flush() {
         state = state.flush();
+        next.flush();
     }
 
     private interface State {

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/OptimizeSetThenPrint.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/OptimizeSetThenPrint.java
@@ -22,6 +22,7 @@ class OptimizeSetThenPrint implements LogicInstructionPipeline {
     @Override
     public void flush() {
         state = state.flush();
+        next.flush();
     }
 
     private interface State {

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/OptimizeSetThenRead.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/OptimizeSetThenRead.java
@@ -17,6 +17,7 @@ class OptimizeSetThenRead implements LogicInstructionPipeline {
     @Override
     public void flush() {
         state = state.flush();
+        next.flush();
     }
 
     private interface State {

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/OptimizeSetThenSet.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/OptimizeSetThenSet.java
@@ -17,6 +17,7 @@ class OptimizeSetThenSet implements LogicInstructionPipeline {
     @Override
     public void flush() {
         state = state.flush();
+        next.flush();
     }
 
     private interface State {

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/OptimizeSetThenWrite.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/OptimizeSetThenWrite.java
@@ -20,6 +20,7 @@ class OptimizeSetThenWrite implements LogicInstructionPipeline {
     @Override
     public void flush() {
         state = state.flush();
+        next.flush();
     }
 
     private interface State {
@@ -66,7 +67,6 @@ class OptimizeSetThenWrite implements LogicInstructionPipeline {
 
         @Override
         public State flush() {
-            next.flush();
             return this;
         }
     }

--- a/compiler/src/test/java/info/teksol/mindcode/mindustry/ImproveConditionalJumpsTest.java
+++ b/compiler/src/test/java/info/teksol/mindcode/mindustry/ImproveConditionalJumpsTest.java
@@ -57,7 +57,7 @@ class ImproveConditionalJumpsTest extends AbstractGeneratorTest {
                                 "  n += 1\n" +
                                 "end\n" +
                                 "\n" +
-                                "while n === null\n" +
+                                "while n == null\n" +
                                 "  n += 1\n" +
                                 "end\n"
                 )


### PR DESCRIPTION
This is a fix for the #64 issue (Optimization should not replace strictEqual with notEqual). There are three commits:
- The first rewrites the **ImproveConditionalJumps** class to use states as described in the issue, and adds a unit test for `strictEqual` comparison handling (this unit test and several others fail).
- The second one makes sure `flush()` propagates correctly down the pipeline. It somehow still worked, but the rewrite broke that in some way and this commit fixes it again.
- The third one fixes the original issue and also updates a unit test that expected `strictEqual` to be handled (which is no longer true after the fix). I changed the test in question to use just `equal`, not `strictEqual`.