### PR TITLE
Issue #70 fix

### DIFF
--- a/bin/mindcode
+++ b/bin/mindcode
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-jar=$( find "$MINDCODE_PATH/webapp" -type f -name '*.jar' | tr '\n' ':' )
-exec java -classpath $jar info.teksol.mindcode.webapp.CompileMain $@
+jar=$( find "$MINDCODE_PATH/compiler" -type f -name '*.jar' | tr '\n' ':' )
+exec java -classpath $jar info.teksol.mindcode.mindustry.CompileMain $@

--- a/bin/mindcode.bat
+++ b/bin/mindcode.bat
@@ -1,0 +1,8 @@
+@echo off
+setlocal enableDelayedExpansion
+pushd %~dp0
+set __CLPATH=.
+for /R ..\compiler\target %%i in (*.jar) do set __CLPATH=!__CLPATH!;%%i
+popd
+"%JAVA_HOME%\bin\java.exe" -classpath !__CLPATH! info.teksol.mindcode.mindustry.CompileMain %*
+endlocal

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/CompileMain.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/CompileMain.java
@@ -1,4 +1,4 @@
-package info.teksol.mindcode.webapp;
+package info.teksol.mindcode.mindustry;
 
 import info.teksol.mindcode.Tuple2;
 import java.io.BufferedReader;
@@ -8,7 +8,7 @@ import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.util.List;
 
-import static info.teksol.mindcode.webapp.CompilerFacade.compile;
+import static info.teksol.mindcode.mindustry.CompilerFacade.compile;
 
 public class CompileMain {
     static private String readFile(String filename) throws IOException {

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/CompilerFacade.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/CompilerFacade.java
@@ -1,21 +1,17 @@
-package info.teksol.mindcode.webapp;
+package info.teksol.mindcode.mindustry;
 
 import info.teksol.mindcode.Tuple2;
 import info.teksol.mindcode.ast.AstNodeBuilder;
 import info.teksol.mindcode.ast.Seq;
 import info.teksol.mindcode.grammar.MindcodeLexer;
 import info.teksol.mindcode.grammar.MindcodeParser;
-import info.teksol.mindcode.mindustry.LogicInstruction;
-import info.teksol.mindcode.mindustry.LogicInstructionGenerator;
-import info.teksol.mindcode.mindustry.LogicInstructionLabelResolver;
-import info.teksol.mindcode.mindustry.LogicInstructionPrinter;
 import org.antlr.v4.runtime.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class CompilerFacade {
-    static Tuple2<String, List<String>> compile(String sourceCode, boolean enableOptimization) {
+    public static Tuple2<String, List<String>> compile(String sourceCode, boolean enableOptimization) {
         String instructions = "";
 
         final MindcodeLexer lexer = new MindcodeLexer(CharStreams.fromString(sourceCode));

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/DeadCodeEliminator.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/DeadCodeEliminator.java
@@ -27,6 +27,7 @@ class DeadCodeEliminator implements LogicInstructionPipeline {
         for (LogicInstruction instruction : program) {
             next.emit(instruction);
         }
+        next.flush();
         program.clear();
     }
 

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/LogicInstructionGenerator.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/LogicInstructionGenerator.java
@@ -26,37 +26,11 @@ public class LogicInstructionGenerator extends BaseAstVisitor<String> {
 
     public static List<LogicInstruction> generateAndOptimize(Seq program) {
         final AccumulatingLogicInstructionPipeline terminus = new AccumulatingLogicInstructionPipeline();
-        final LogicInstructionPipeline pipeline =
-                new DeadCodeEliminator(
-                        new SingleStepJumpEliminator(
-                                new OptimizeSensorThenSet(
-                                        new OptimizeOpThenSet(
-                                                new OptimizeSetThenWrite(
-                                                        new OptimizeReadThenSet(
-                                                                new OptimizeSetThenRead(
-                                                                        new OptimizeSetThenOp(
-                                                                                new OptimizeSetThenSet(
-                                                                                        new OptimizeSetThenPrint(
-                                                                                                new OptimizeGetlinkThenSet(
-                                                                                                        new ImproveConditionalJumps(
-                                                                                                                    terminus
-                                                                                                        )                                                                                                                
-                                                                                                )
-                                                                                        )
-                                                                                )
-                                                                        )
-                                                                )
-                                                        )
-                                                )
-                                        )
-                                )
-                        )
-                );
-
+        LogicInstructionPipeline pipeline = Optimisation.createCompletePipeline(terminus);
         LogicInstructionGenerator generator = new LogicInstructionGenerator(pipeline);
         generator.start(program);
         pipeline.flush();
-
+        
         return terminus.getResult();
     }
 

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/Optimisation.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/Optimisation.java
@@ -1,0 +1,54 @@
+package info.teksol.mindcode.mindustry;
+
+import java.util.EnumSet;
+import java.util.function.Function;
+
+// The optimizations are applied in the declared order, ie. DeadCodeEliminator gets instructions from the 
+// compiler, makes optimizations and passes them onto the next optimizer.
+public enum Optimisation {
+    DEAD_CODE_ELIMINATION               (next -> new DeadCodeEliminator(next)),
+    SINGLE_STEP_JUMP_ELIMINATION        (next -> new SingleStepJumpEliminator(next)),
+    SENSOR_THEN_SET_OPTIMIZATION        (next -> new OptimizeSensorThenSet(next)),
+    OP_THEN_SET_OPTIMIZATION            (next -> new OptimizeOpThenSet(next)),
+    SET_THEN_WRITE_OPTIMIZATION         (next -> new OptimizeSetThenWrite(next)),
+    READ_THEN_SET_OPTIMIZATION          (next -> new OptimizeReadThenSet(next)),
+    SET_THEN_READ_OPTIMIZATION          (next -> new OptimizeSetThenRead(next)),
+    SET_THEN_OP_OPTIMIZATION            (next -> new OptimizeSetThenOp(next)),
+    SET_THEN_SET_OPTIMIZATION           (next -> new OptimizeSetThenSet(next)),
+    SET_THEN_PRINT_OPTIMIZATION         (next -> new OptimizeSetThenPrint(next)),
+    GETLINK_THEN_SET_OPTIMIZATION       (next -> new OptimizeGetlinkThenSet(next)),
+    CONDITIONAL_JUMPS_IMPROVEMENT       (next -> new ImproveConditionalJumps(next)),
+    ;
+    
+    private final Function<LogicInstructionPipeline, LogicInstructionPipeline> instanceCreator;
+
+    private Optimisation(Function<LogicInstructionPipeline, LogicInstructionPipeline> instanceCreator) {
+        this.instanceCreator = instanceCreator;
+    }
+    
+    private LogicInstructionPipeline createInstance(LogicInstructionPipeline next) {
+        return instanceCreator.apply(next);
+    }
+    
+    public static LogicInstructionPipeline createCompletePipeline(LogicInstructionPipeline terminus) {
+        LogicInstructionPipeline pipeline = terminus;
+        Optimisation[] values = values();
+        for (int i = values.length - 1; i >= 0; i--) {
+            pipeline = values[i].createInstance(pipeline);
+            
+        }
+        return pipeline;
+    }
+    
+    public static LogicInstructionPipeline createPipelineOf(LogicInstructionPipeline terminus, Optimisation... optimizers) {
+        EnumSet<Optimisation> includes = EnumSet.of(optimizers[0], optimizers);
+        LogicInstructionPipeline pipeline = terminus;
+        Optimisation[] values = values();
+        for (int i = values.length - 1; i >= 0; i--) {
+            if (includes.contains(values[i])) {
+                pipeline = values[i].createInstance(pipeline);
+            }
+        }
+        return pipeline;
+    }
+}

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/SingleStepJumpEliminator.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/SingleStepJumpEliminator.java
@@ -29,6 +29,7 @@ class SingleStepJumpEliminator implements LogicInstructionPipeline {
     @Override
     public void flush() {
         state = state.flush();
+        next.flush();
     }
 
     private interface State {

--- a/webapp/src/main/java/info/teksol/mindcode/webapp/HomeController.java
+++ b/webapp/src/main/java/info/teksol/mindcode/webapp/HomeController.java
@@ -20,7 +20,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static info.teksol.mindcode.webapp.CompilerFacade.compile;
+import static info.teksol.mindcode.mindustry.CompilerFacade.compile;
 
 @Controller
 @RequestMapping(value = "/")

--- a/webapp/src/main/java/info/teksol/mindcode/webapp/ScriptsController.java
+++ b/webapp/src/main/java/info/teksol/mindcode/webapp/ScriptsController.java
@@ -14,7 +14,7 @@ import java.sql.ResultSet;
 import java.util.List;
 import java.util.UUID;
 
-import static info.teksol.mindcode.webapp.CompilerFacade.compile;
+import static info.teksol.mindcode.mindustry.CompilerFacade.compile;
 import static org.springframework.http.HttpStatus.*;
 
 @Controller


### PR DESCRIPTION
First a technical note: as of now, I have several changes lined up in a linear fashion ready to create pull requests from. I thought I might create a few stacked pull requests. It looks like GitHub doesn't offer a possibility to show diffs against the previous PR, but it is possible to show diff based on a selection of commits, which I hope will make reviews of stacked PRs possible.

Please go through the pull requests in the order they were created and stop when you find some which isn't ready. I'll then rebase the pending pull requests to reflect merging of the accepted ones into your repo and any changes resulting from reviews.

---------------------

This PR implements the changes I proposed in #70. Quick notes on the commits:

- Issue 70 (moved CompileMain to compiler project) - I moved both the CompilerMain and CompilerFacade classes into the compiler project, created a Windows bat file mindcode.bat to run the compiler (it's modeled after the linux counterpart) and also updated the path in the mindcode Linux shell script, but wasn't able to test it.
- Issue 70 (Optimizer enum): the new enum is actually called Optimisation, and it contains enum corresponding to all existing optimizer classes. It provides a static method to construct the optimisation pipeline, which is used to replace explicit pipeline creation in the LogicInstructionGenerator class.
- Fix two more missing flush() calls: as the title says, a trivial bug fix.
