### PR TITLE
Propagate jump target

### DIFF
--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/LogicInstruction.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/LogicInstruction.java
@@ -60,6 +60,10 @@ public class LogicInstruction {
         return opcode.equals("sensor");
     }
 
+    public boolean isEnd() {
+        return opcode.equals("end");
+    }
+
     public String getOpcode() {
         return opcode;
     }

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/LogicInstructionGenerator.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/LogicInstructionGenerator.java
@@ -34,7 +34,7 @@ public class LogicInstructionGenerator extends BaseAstVisitor<String> {
         return terminus.getResult();
     }
 
-    static void generateInto(LogicInstructionPipeline pipeline, Seq program) {
+    public static void generateInto(LogicInstructionPipeline pipeline, Seq program) {
         LogicInstructionGenerator generator = new LogicInstructionGenerator(pipeline);
         generator.start(program);
         pipeline.flush();

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/Optimisation.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/Optimisation.java
@@ -1,5 +1,6 @@
 package info.teksol.mindcode.mindustry;
 
+import info.teksol.mindcode.mindustry.optimisation.PropagateJumpTargets;
 import java.util.EnumSet;
 import java.util.function.Function;
 
@@ -18,6 +19,7 @@ public enum Optimisation {
     SET_THEN_PRINT_OPTIMIZATION         (next -> new OptimizeSetThenPrint(next)),
     GETLINK_THEN_SET_OPTIMIZATION       (next -> new OptimizeGetlinkThenSet(next)),
     CONDITIONAL_JUMPS_IMPROVEMENT       (next -> new ImproveConditionalJumps(next)),
+    JUMP_TARGET_PROPAGATION             (next -> new PropagateJumpTargets(next)),
     ;
     
     private final Function<LogicInstructionPipeline, LogicInstructionPipeline> instanceCreator;

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/optimisation/BaseOptimizer.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/optimisation/BaseOptimizer.java
@@ -1,0 +1,28 @@
+package info.teksol.mindcode.mindustry.optimisation;
+
+import info.teksol.mindcode.mindustry.LogicInstruction;
+import info.teksol.mindcode.mindustry.LogicInstructionPipeline;
+import java.util.ArrayList;
+import java.util.List;
+
+// Base class for optimizers. Contains helper functions for manipulating instructions.
+abstract class BaseOptimizer implements LogicInstructionPipeline {
+    protected final LogicInstructionPipeline next;
+
+    public BaseOptimizer(LogicInstructionPipeline next) {
+        this.next = next;
+    }
+
+    // Creates a new instruction with argument given index set to a new value
+    protected LogicInstruction replaceArg(LogicInstruction instruction, int argIndex, String arg) {
+        if (instruction.getArgs().get(argIndex).equals(arg)) {
+            return instruction;
+        }
+        else {
+            List<String> newArgs = new ArrayList<>(instruction.getArgs());
+            newArgs.set(argIndex, arg);
+            return new LogicInstruction(instruction.getOpcode(), newArgs);
+        }
+    }
+    
+}

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/optimisation/GlobalOptimizer.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/optimisation/GlobalOptimizer.java
@@ -1,0 +1,51 @@
+package info.teksol.mindcode.mindustry.optimisation;
+
+import info.teksol.mindcode.mindustry.LogicInstruction;
+import info.teksol.mindcode.mindustry.LogicInstructionPipeline;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+// Base class for global optimizers. Consumes the netire program before performing optimizations on it.
+// Contains helper method to navigate and manipulate the program.
+abstract class GlobalOptimizer extends BaseOptimizer {
+    protected final List<LogicInstruction> program = new ArrayList<>();
+    
+    public GlobalOptimizer(LogicInstructionPipeline next) {
+        super(next);
+    }
+
+    @Override
+    public void emit(LogicInstruction instruction) {
+        program.add(instruction);
+    }
+
+    @Override
+    public void flush() {
+        optimizeProgram();
+        program.forEach(next::emit);
+        next.flush();
+    }
+    
+    protected abstract void optimizeProgram();
+
+    // Starting at index, finds first instruction matching predicate.
+    // Returns the index or -1 if not found.
+    protected int findInstructionIndex(int index, Predicate<LogicInstruction> matcher) {
+        for (int i = index; i < program.size(); i++) {
+            LogicInstruction instruction = program.get(i);
+            if (matcher.test(instruction)) {
+                return i;
+            }
+        }
+        
+        return -1;
+    }
+    
+    // Starting at index, find first instruction matching predicate. Return null if not found.
+    protected LogicInstruction findInstruction(int index, Predicate<LogicInstruction> matcher) {
+        int result = findInstructionIndex(index, matcher);
+        return result < 0 ? null : program.get(result);
+    }
+    
+}

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/optimisation/PropagateJumpTargets.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/optimisation/PropagateJumpTargets.java
@@ -1,0 +1,96 @@
+package info.teksol.mindcode.mindustry.optimisation;
+
+import edu.emory.mathcs.backport.java.util.Collections;
+import info.teksol.mindcode.mindustry.LogicInstruction;
+import info.teksol.mindcode.mindustry.LogicInstructionPipeline;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+// If a jump (conditional or unconditional) targets an unconditional jump, the target of the first jump is redirected
+// to the target of the second jump, repeated until the end of jump chain is reached. Moreover:
+// - end instruction is handled identically to jump 0 always
+// - conditional jumps in the jump chain are followed if
+//    (i) their condition is equal the the condition the first jump, and
+//   (ii) the condition arguments do not contain a volatile variable (@time, @tick or @counter)
+//
+// Jump retargeting can move targets forward or backward over long distances; therefore the optimizer is global.
+// No instructions are removed or added except a label at the start of the program.
+public class PropagateJumpTargets extends GlobalOptimizer {
+    private static final String FIRST_LABEL = "__start__";
+    private static final Set<String> EXCLUDED_ARGS = Set.of("@time", "@tick", "@counter");
+    private boolean startLabelUsed = false;
+    
+    public PropagateJumpTargets(LogicInstructionPipeline next) {
+        super(next);
+    }
+    
+    @Override
+    protected void optimizeProgram() {
+        program.add(0, new LogicInstruction("label", FIRST_LABEL));
+        for (int index = 0; index < program.size(); index++) {
+            LogicInstruction instruction = program.get(index);
+            if (instruction.isJump()) {
+                String label = findJumpRedirection(instruction);
+                if (!label.equals(instruction.getArgs().get(0))) {
+                    startLabelUsed |= label.equals(FIRST_LABEL);
+                    // Update target of the original jump
+                    program.set(index, replaceArg(instruction, 0, label));
+                }
+            }
+        }
+        
+        if (!startLabelUsed) {
+            // Keep start label only if used -- easier on some unit tests
+            program.remove(0);
+        }
+    }
+
+    // Determines the final target of given jump
+    private String findJumpRedirection(LogicInstruction firstJump) {
+        String label = firstJump.getArgs().get(0);
+        Set<String> labels = new HashSet<>();       // Cycle detection
+        labels.add(label);
+        while (true) {
+            String redirected = evaluateJumpRedirection(firstJump, label);
+            if (redirected == null || !labels.add(redirected)) {
+                return label;
+            }
+            label = redirected;
+        }
+    }
+    
+    // Determines the jump redirection (one level only)
+    private String evaluateJumpRedirection(LogicInstruction firstJump, String label) {
+        int target = findInstructionIndex(0, ix -> ix.isLabel() && ix.getArgs().get(0).equals(label));
+        if (target < 0) {
+            throw new IllegalStateException("Could not find label " + label);
+        }
+
+        // Find next real instruction
+        LogicInstruction next = findInstruction(target + 1, ix -> !ix.isLabel());
+        
+        // Redirect compatible jumps
+        if (next.isJump() && (next.getArgs().get(1).equals("always") || isIdenticalJump(firstJump, next))) {
+            return next.getArgs().get(0);
+        } 
+
+        // end() is always compatible
+        if (next.isEnd()) {
+            return FIRST_LABEL;
+        }
+
+        // Not an unconditional or compatible jump: no redirection
+        return null;
+    }
+    
+    // Returns true if the next jump is semantically identical to the first jump
+    private boolean isIdenticalJump(LogicInstruction firstJump, LogicInstruction nextJump) {
+        List<String> args1 = firstJump.getArgs();
+        List<String> args2 = nextJump.getArgs();
+        
+        // Compare everything but labels; exclude volatile variables
+        return args1.subList(1, args1.size()).equals(args2.subList(1, args2.size())) &&
+                Collections.disjoint(args1, EXCLUDED_ARGS);
+    }
+}

--- a/compiler/src/test/java/info/teksol/mindcode/mindustry/optimisation/PropagateJumpTargetsTest.java
+++ b/compiler/src/test/java/info/teksol/mindcode/mindustry/optimisation/PropagateJumpTargetsTest.java
@@ -1,0 +1,127 @@
+package info.teksol.mindcode.mindustry.optimisation;
+
+import info.teksol.mindcode.ast.Seq;
+import info.teksol.mindcode.mindustry.AbstractGeneratorTest;
+import info.teksol.mindcode.mindustry.LogicInstruction;
+import info.teksol.mindcode.mindustry.LogicInstructionGenerator;
+import info.teksol.mindcode.mindustry.LogicInstructionPipeline;
+import info.teksol.mindcode.mindustry.Optimisation;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class PropagateJumpTargetsTest extends AbstractGeneratorTest {
+    private final LogicInstructionPipeline sut = Optimisation.createPipelineOf(terminus, 
+            Optimisation.DEAD_CODE_ELIMINATION,
+            Optimisation.CONDITIONAL_JUMPS_IMPROVEMENT,
+            Optimisation.JUMP_TARGET_PROPAGATION,
+            Optimisation.SET_THEN_PRINT_OPTIMIZATION,
+            Optimisation.OP_THEN_SET_OPTIMIZATION,
+            Optimisation.SET_THEN_OP_OPTIMIZATION,
+            Optimisation.GETLINK_THEN_SET_OPTIMIZATION
+    );
+
+    @Test
+    void propagatesThroughUnconditionalTargets() {
+        LogicInstructionGenerator.generateInto(
+                sut,
+                (Seq) translateToAst(
+                        "" +
+                                "if a\n" +
+                                "  if b\n" +
+                                "    print(b)\n" +
+                                "  end\n" +
+                                "  print(a)\n" +
+                                "end"
+                )
+        );
+
+        assertLogicInstructionsMatch(
+                List.of(
+                        new LogicInstruction("label", "__start__"),
+                        new LogicInstruction("jump", "__start__", "notEqual", "a", "true"),
+                        new LogicInstruction("jump", var(1002), "notEqual", "b", "true"),
+                        new LogicInstruction("print", "b"),
+                        new LogicInstruction("jump", var(1003), "always"),
+                        new LogicInstruction("label", var(1002)),
+                        new LogicInstruction("label", var(1003)),
+                        new LogicInstruction("print", "a"),
+                        new LogicInstruction("jump", "__start__", "always"),
+                        new LogicInstruction("label", var(1000)),
+                        new LogicInstruction("label", var(1001)),
+                        new LogicInstruction("end")
+                ),
+                terminus.getResult()
+        );
+    }
+    
+    @Test
+    void propagatesThroughConditionalTargets() {
+        LogicInstructionGenerator.generateInto(
+                sut,
+                (Seq) translateToAst(
+                        "" +
+                                "while c == null\n" +
+                                "  c = getlink(1)\n" +
+                                "  if c == null\n" +
+                                "    print(\"Not found\")\n" +
+                                "  end\n" +
+                                "end\n" +
+                                "print(\"Done\")"
+                )
+        );
+
+        assertLogicInstructionsMatch(
+                List.of(
+                        new LogicInstruction("label", var(1000)),
+                        new LogicInstruction("jump", var(1001), "notEqual", "c", "null"),
+                        new LogicInstruction("set", var(1), "1"),
+                        new LogicInstruction("getlink", "c", var(1)),
+                        new LogicInstruction("jump", var(1001), "notEqual", "c", "null"),
+                        new LogicInstruction("print", "\"Not found\""),
+                        new LogicInstruction("jump", var(1000), "always"),
+                        new LogicInstruction("label", var(1002)),
+                        new LogicInstruction("label", var(1003)),
+                        new LogicInstruction("jump", var(1000), "always"),
+                        new LogicInstruction("label", var(1001)),
+                        new LogicInstruction("print", "\"Done\""),
+                        new LogicInstruction("end")
+                ),
+                terminus.getResult()
+        );
+    }
+    
+    @Test
+    void ignoresVolatileVariables() {
+        LogicInstructionGenerator.generateInto(
+                sut,
+                (Seq) translateToAst(
+                        "" +
+                                "while @time < wait\n" +
+                                "  n += 1\n" +
+                                "  if @time < wait\n" +
+                                "    print(\"Waiting\")\n" +
+                                "  end\n" +
+                                "end\n" +
+                                "print(\"Done\")"
+                )
+        );
+
+        assertLogicInstructionsMatch(
+                List.of(
+                        new LogicInstruction("label", var(1000)),
+                        new LogicInstruction("jump", var(1001), "greaterThanEq", "@time", "wait"),
+                        new LogicInstruction("op", "add", "n", "n", "1"),
+                        new LogicInstruction("jump", var(1000), "greaterThanEq", "@time", "wait"),
+                        new LogicInstruction("print", "\"Waiting\""),
+                        new LogicInstruction("jump", var(1000), "always"),
+                        new LogicInstruction("label", var(1002)),
+                        new LogicInstruction("label", var(1003)),
+                        new LogicInstruction("jump", var(1000), "always"),
+                        new LogicInstruction("label", var(1001)),
+                        new LogicInstruction("print", "\"Done\""),
+                        new LogicInstruction("end")
+                ),
+                terminus.getResult()
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces a new optimizer which turns a series of jumps that lead from one to another into a single jump right to the target of the last jump. These jump chains are typical for nested code blocks (loops/ifs) with some instructions before/after the code blocks. This optimization doesn't decrease the number of instructions, but reduces execution time by avoiding all but the first one of the jumps.

Preconditions for the optimisation: if a jump (conditional or unconditional) targets an unconditional jump, the target of the first jump is redirected to the target of the second jump, repeated until the end of jump chain is reached. Moreover:
- end instruction is handled identically to jump 0 always
- conditional jumps in the jump chain are followed if
   - their condition is equal to the condition of the first jump, and
   - the condition arguments do not contain a volatile variable (@time, @tick or @counter)

This optimizer is a global one - it needs to look at the entire program at once, similarly to what DeadCodeEliminator does.

Other highlights:

- BaseOptimiser: new base class for all future optimizers. Will be a bit expanded in the future.
- GlobalOptimisers: new base class for future global optimizers. It collects all the instructions an then calls `optimizeProgram`, the only method child classes need to implement. Then it sends the resulting, optimized program down the pipeline.
