### PR TITLE
Print merger

### DIFF
--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/optimisation/Optimisation.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/optimisation/Optimisation.java
@@ -16,6 +16,7 @@ public enum Optimisation {
     OUTPUT_TEMPS_ELIMINATION            (next -> new OutputTempEliminator(next)),
     CASE_EXPRESSION_OPTIMIZATION        (next -> new CaseExpressionOptimizer(next)),
     CONDITIONAL_JUMPS_IMPROVEMENT       (next -> new ImproveConditionalJumps(next)),
+    PRINT_TEXT_MERGING                  (next -> new PrintMerger(next)),
     JUMP_TARGET_PROPAGATION             (next -> new PropagateJumpTargets(next)),
     // This optimizer can create additional single step jumps; therefore is bundled with its eliminator
     INACCESSIBLE_CODE_ELIMINATION       (next -> new InaccesibleCodeEliminator(new SingleStepJumpEliminator(next))),

--- a/compiler/src/main/java/info/teksol/mindcode/mindustry/optimisation/PrintMerger.java
+++ b/compiler/src/main/java/info/teksol/mindcode/mindustry/optimisation/PrintMerger.java
@@ -1,0 +1,119 @@
+package info.teksol.mindcode.mindustry.optimisation;
+
+import info.teksol.mindcode.mindustry.LogicInstruction;
+import info.teksol.mindcode.mindustry.LogicInstructionPipeline;
+import java.util.ArrayList;
+import java.util.List;
+
+// A simple optimizer which merges together print instructions with string literal arguments.
+// The print instructions will get merged even if they aren't consecutive, assuming there aren't instructions
+// that could break the print sequence (jump, label or print [variable]).
+// Typical sequence of instructions targeted by this optimizer is:
+//
+// print count
+// print "\n"
+// op div ratio count total
+// op mul ratio ratio 100
+// print "Used: "
+// print ratio
+// print "%"
+//
+// Which will get turned to
+//
+// print count
+// op div ratio count total
+// op mul ratio ratio 100
+// print "\nUsed: "
+// print ratio
+// print "%"
+//
+class PrintMerger extends PipelinedOptimizer {
+    public PrintMerger(LogicInstructionPipeline next) {
+        super(next);
+    }
+    
+    @Override
+    protected State initialState() {
+        return new EmptyState();
+    }
+
+    private final class EmptyState implements State {
+        @Override
+        public State emit(LogicInstruction instruction) {
+            if (instruction.isPrint() && instruction.getArgs().get(0).startsWith("\"")) {
+                return new ExpectPrint(instruction);
+            } else {
+                emitToNext(instruction);
+                return this;
+            }
+        }
+
+        @Override
+        public State flush() {
+            return this;
+        }
+    }
+
+    private final class ExpectPrint implements State {
+        private final LogicInstruction firstPrint;
+        private List<LogicInstruction> operations = new ArrayList<>();
+        
+        private ExpectPrint(LogicInstruction instruction) {
+            firstPrint = instruction;
+        }
+        
+        @Override
+        public State emit(LogicInstruction instruction) {
+            // Do not merge across jumps and labela
+            // Function calls generate a label, so they prevent merging as well
+            if (instruction.isJump() || instruction.isLabel()) {
+                operations.add(instruction);
+                return flush();
+            }
+            
+            if (instruction.isPrint()) {
+                // Only merge string literals
+                if (instruction.getArgs().get(0).startsWith("\"")) {
+                    LogicInstruction merged = merge(firstPrint, instruction);
+                    if (merged != null) {
+                        operations.forEach(PrintMerger.this::emitToNext);
+                        // We can merge the merged instruction with next one as well
+                        return new ExpectPrint(merged);
+                    } else {
+                        // We didn't merge for whatever reason.
+                        // Try to merge current instruction with the next one
+                        flush();
+                        return new ExpectPrint(instruction);
+                    }
+                }
+                
+                // Any other print breaks the sequence and cannot be merged
+                operations.add(instruction);
+                return flush();
+            }
+            
+            operations.add(instruction);
+            return this;
+        }
+
+        // Creates a merged instruction from two constant prints
+        // If merge is not possible (the string constants are malformed), returns null.
+        // Only checks for quotes on both ends of the string, doesn't check for proper quote escaping
+        private LogicInstruction merge(LogicInstruction first, LogicInstruction second) {
+            String str1 = first.getArgs().get(0);
+            String str2 = second.getArgs().get(0);
+            if (str1.startsWith("\"") && str1.endsWith("\"") && str2.startsWith("\"") && str2.endsWith("\"")) {
+                return new LogicInstruction(first.getOpcode(), str1.substring(0, str1.length() - 1) + str2.substring(1));
+            }
+            
+            return null;
+        }
+
+        @Override
+        public State flush() {
+            emitToNext(firstPrint);
+            operations.forEach(PrintMerger.this::emitToNext);
+            return new EmptyState();
+        }
+    }
+}

--- a/compiler/src/test/java/info/teksol/mindcode/mindustry/optimisation/PrintMergerTest.java
+++ b/compiler/src/test/java/info/teksol/mindcode/mindustry/optimisation/PrintMergerTest.java
@@ -1,0 +1,133 @@
+package info.teksol.mindcode.mindustry.optimisation;
+
+import info.teksol.mindcode.ast.Seq;
+import info.teksol.mindcode.mindustry.AbstractGeneratorTest;
+import info.teksol.mindcode.mindustry.LogicInstruction;
+import info.teksol.mindcode.mindustry.LogicInstructionGenerator;
+import info.teksol.mindcode.mindustry.LogicInstructionPipeline;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class PrintMergerTest  extends AbstractGeneratorTest {
+    private final LogicInstructionPipeline pipeline = Optimisation.createPipelineOf(terminus, 
+            Optimisation.INPUT_TEMPS_ELIMINATION,
+            Optimisation.PRINT_TEXT_MERGING
+    );
+
+    @Test
+    void mergesTwoPrints() {
+        LogicInstructionGenerator.generateInto(
+                pipeline,
+                (Seq) translateToAst("" +
+                        "print(\"a\")\n" +
+                        "print(\"b\")"
+                )
+        );
+
+        assertLogicInstructionsMatch(
+                List.of(
+                        new LogicInstruction("print", "\"ab\""),
+                        new LogicInstruction("end")
+                ),
+                terminus.getResult()
+        );
+    }
+
+    @Test
+    void mergesThreePrints() {
+        LogicInstructionGenerator.generateInto(
+                pipeline,
+                (Seq) translateToAst("" +
+                        "print(\"a\")\n" +
+                        "print(\"b\")\n" +
+                        "print(\"c\")"
+                )
+        );
+
+        assertLogicInstructionsMatch(
+                List.of(
+                        new LogicInstruction("print", "\"abc\""),
+                        new LogicInstruction("end")
+                ),
+                terminus.getResult()
+        );
+    }
+
+    @Test
+    void handlesInterleavedPrints() {
+        LogicInstructionGenerator.generateInto(
+                pipeline,
+                (Seq) translateToAst("" +
+                        "print(\"a\")\n" +
+                        "print(x)\n" +
+                        "print(\"c\")" +
+                        "print(\"d\")"
+                )
+        );
+
+        assertLogicInstructionsMatch(
+                List.of(
+                        new LogicInstruction("print", "\"a\""),
+                        new LogicInstruction("print", "x"),
+                        new LogicInstruction("print", "\"cd\""),
+                        new LogicInstruction("end")
+                ),
+                terminus.getResult()
+        );
+    }
+    
+    @Test
+    void skipsJumps() {
+        LogicInstructionGenerator.generateInto(
+                pipeline,
+                (Seq) translateToAst("" +
+                        "print(\"a\")\n" +
+                        "if x\n" +
+                        "  print(x)\n" +
+                        "end\n" +
+                        "print(\"b\")"
+                )
+        );
+
+        assertLogicInstructionsMatch(
+                List.of(
+                        new LogicInstruction("print", "\"a\""),
+                        new LogicInstruction("jump", var(1000), "notEqual", "x", "true"),
+                        new LogicInstruction("print", "x"),
+                        new LogicInstruction("set", var(1), "x"),
+                        new LogicInstruction("jump", var(1001), "always"),
+                        new LogicInstruction("label", var(1000)),
+                        new LogicInstruction("set", var(1), "null"),
+                        new LogicInstruction("label", var(1001)),
+                        new LogicInstruction("print", "\"b\""),
+                        new LogicInstruction("end")
+                ),
+                terminus.getResult()
+        );
+    }
+
+    @Test
+    void mergesAcrossInstructions() {
+        LogicInstructionGenerator.generateInto(
+                pipeline,
+                (Seq) translateToAst("" +
+                        "print(\"Rate: \", rate, \" items/sec\", \"\\n\")\n" +
+                        "print(\"Elapsed: \", @time - start, \" ms\")"
+                )
+        );
+
+        assertLogicInstructionsMatch(
+                List.of(
+                        new LogicInstruction("print", "\"Rate: \""),
+                        new LogicInstruction("print", "rate"),
+                        new LogicInstruction("op", "sub", var(0), "@time", "start"),
+                        new LogicInstruction("print", "\" items/sec\\nElapsed: \""),
+                        new LogicInstruction("print", var(0)),
+                        new LogicInstruction("print", "\" ms\""),
+                        new LogicInstruction("end")
+                ),
+                terminus.getResult()
+        );
+    }
+
+}


### PR DESCRIPTION
A simple optimizer which merges print instructions with string literals. The prints are merged even if there are instructions in between them, except jumps, labels and non-constant prints -- if these conditions are met, there's a linear flow of instructions between the two prints which are guaranteed not to change the print buffer, therefore rearranging the prints is safe.