### PR TITLE
Add autoPathfind()

### DIFF
--- a/doc/syntax/FUNCTIONS_V7A.markdown
+++ b/doc/syntax/FUNCTIONS_V7A.markdown
@@ -185,6 +185,7 @@ Control the currently bound unit.
 |`stop()`|`ucontrol stop 0 0 0 0 0`|
 |`move(x, y)`|`ucontrol move x y 0 0 0`|
 |`approach(x, y, radius)`|`ucontrol approach x y radius 0 0`|
+|`autoPathfind()`|`ucontrol autoPathfind 0 0 0 0 0`|
 |`pathfind(x, y)`|`ucontrol pathfind x y 0 0 0`|
 |`boost(enable)`|`ucontrol boost enable 0 0 0 0`|
 |`target(x, y, shoot)`|`ucontrol target x y shoot 0 0`|

--- a/mindcode/src/main/java/info/teksol/mindcode/logic/MindustryOpcodeVariants.java
+++ b/mindcode/src/main/java/info/teksol/mindcode/logic/MindustryOpcodeVariants.java
@@ -130,6 +130,7 @@ public class MindustryOpcodeVariants {
         add(list, V6, V7A, S, FUNC, Opcode.UCONTROL,   uctrl("stop"));
         add(list, V6, V7A, S, FUNC, Opcode.UCONTROL,   uctrl("move"),      in("x"), in("y"));
         add(list, V6, V7A, S, FUNC, Opcode.UCONTROL,   uctrl("approach"),  in("x"), in("y"), in("radius"));
+        add(list, V7, V7A, S, FUNC, Opcode.UCONTROL,   uctrl("autoPathfind"));
         add(list, V7, V7A, S, FUNC, Opcode.UCONTROL,   uctrl("pathfind"),  in("x"), in("y"));
         add(list, V6, V7A, S, FUNC, Opcode.UCONTROL,   uctrl("boost"),     in("enable"));
         add(list, V6, V6,  S, FUNC, Opcode.UCONTROL,   uctrl("pathfind"));


### PR DESCRIPTION
In the latest Mindustry 146, a new ucontrol autoPathfind 0 0 0 0 0 has been added.

> - Added logic unit autoPathfind command (default wave pathfinding)

[Mindustry release notes](https://github.com/Anuken/Mindustry/releases/tag/v146)